### PR TITLE
Refactor/rename above below with during

### DIFF
--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -59,7 +59,7 @@
     (apply sdo child-stream)))
 
 (defn condition-during
-  "if the condition `condition-fn`(which should be function accepting an event)is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
+  "if the condition `condition-fn`(which should be function accepting an event) is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
   `:metric` should not be nil (it will produce exceptions).
 
   `opts` keys:
@@ -291,27 +291,28 @@ Example:
     (scount opts
       (apply sdo child-streams))))
 
-(defn regex-dt
-  "if regex `:pattern` matched all events received during at least the period `dt`, matched events received after the `dt`
-  period will be passed on until an invalid event arrives.  The matched event `:state` will be set to `critical` and forward to children.
+(defn regex-during
+  "if regex `:pattern` matched all events received during at least the period `dt`, matched events received after the `dt` period will be passed on until an invalid event arrives.  The matched event `:state` will be set to `critical` and forward to children.
   `:metric` should not be nil (it will produce exceptions).
 
 
   `opts` keys:
   - `:pattern`  : A string regex
   - `:duration` : The time period in seconds.
+  - `:state`    : The state of event forwarded to children.
 
   Example:
 
-  (regex-dt {:pattern '.*(?i)error.*' :duration 10 } 
-            children)"
+  (regex-dt {:pattern '.*(?i)error.*' :duration 10 :state \"critical\"} 
+            children)
 
+  Set `:state` to \"critical\" if metric of events contain \"error\" during 10 sec or more."
   [opts & children]
 
   (apply condition-during {:condition-fn #(re-matches (re-pattern (:pattern opts)) (:metric %)) 
-                              :duration (:duration opts) 
-                              :state "critical"} 
-                             children))
+                           :duration (:duration opts) 
+                           :state (:state opts)} 
+                          children))
 
 (defn expired-host
   [opts & children]
@@ -341,7 +342,7 @@ Example:
             :scount scount
             :scount-crit scount-crit
             :percentiles-crit percentiles-crit
-            :regex-dt regex-dt
+            :regex-during regex-during
             :critical critical)
         streams (mapv (fn [config]
                         (let [children (:children config)

--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -86,7 +86,7 @@
       (fn [event]
         (call-rescue event children)))))
 
-(defn above
+(defn above-during
   "If the condition `(> (:metric event) threshold)` is valid for all events
   received during at least the period `dt`, valid events received after the `dt`
   period will be passed on until an invalid event arrives. Forward to children.
@@ -94,16 +94,17 @@
 
   `opts` keys:
   - `:threshold` : The threshold used by the above stream
-  - `:duration`   : The time period in seconds.
+  - `:duration`  : The time period in seconds.
+  - `:state`     : The state of event forwarded to children.
 
   Example:
 
-  (above {:threshold 70 :duration 10} email)
+  (above-during {:threshold 70 :duration 10 :state 'critical'} email)
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 during 10 sec or more."
   [opts & children]
   (dt/above (:threshold opts) (:duration opts)
-    (with :state "critical"
+    (with :state (:state opts)
       (fn [event]
         (call-rescue event children)))))
 
@@ -336,7 +337,7 @@ Example:
             :threshold threshold
             :condition condition
             :condition-during condition-during
-            :above above
+            :above-during above-during
             :below below
             :scount scount
             :scount-crit scount-crit

--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -36,9 +36,7 @@
     (apply sdo child-streams)))
 
 (defn condition
-  "Use the `:condition-fn` value (which should be function
-  accepting an event) to set the event `:state` accordely. Forward events to
-  children
+  "Use the `:condition-fn` value (which should be function accepting an event) to set the event `:state` accordely. Forward events to children
 
   `opts` keys:
   - `:condition-fn` : A function accepting an event and returning a boolean 
@@ -61,9 +59,7 @@
     (apply sdo child-stream)))
 
 (defn condition-during
-  "if the condition `condition-fn`(which should be function accepting an event)is valid for all events
-  received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. 
-  Forward to children.
+  "if the condition `condition-fn`(which should be function accepting an event)is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
   `:metric` should not be nil (it will produce exceptions).
 
   `opts` keys:
@@ -87,9 +83,7 @@
         (call-rescue event children)))))
 
 (defn above-during
-  "If the condition `(> (:metric event) threshold)` is valid for all events
-  received during at least the period `dt`, valid events received after the `dt`
-  period will be passed on until an invalid event arrives. Forward to children.
+  "If the condition `(> (:metric event) threshold)` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
   `:metric` should not be nil (it will produce exceptions).
 
   `opts` keys:
@@ -109,9 +103,7 @@
         (call-rescue event children)))))
 
 (defn below-during
-  "If the condition `(< (:metric event) threshold)` is valid for all events
-  received during at least the period `dt`, valid events received after the `dt`
-  period will be passed on until an invalid event arrives. Forward to children.
+  "If the condition `(< (:metric event) threshold)` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
   `:metric` should not be nil (it will produce exceptions).
 
   `opts` keys:
@@ -136,7 +128,8 @@
   `opts` keys:
   - `:min-threshold` : The min threshold
   - `:max-threshold` : The max threshold
-  - `:duration`   : The time period in seconds.
+  - `:duration`      : The time period in seconds.
+  - `:state`         : The state of event forwarded to children.
 
   Example:
 
@@ -152,26 +145,28 @@
       (fn [event]
         (call-rescue event children)))))
 
-(defn between
+(defn between-during
   "If the condition `(and (> (:metric event) low) (< (:metric event) high))` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives.
 
   `:metric` should not be nil (it will produce exceptions).
   `opts` keys:
   - `:min-threshold` : The min threshold
   - `:max-threshold` : The max threshold
-  - `:duration`   : The time period in seconds.
+  - `:duration`      : The time period in seconds.
+  - `:state`         : The state of event forwarded to children.
 
   Example:
 
-  (between {:min-threshold 70
-            :max-threshold 90
-            :duration 10
-            :service \"bar\"})
+  (between-during {:min-threshold 70
+                   :max-threshold 90
+                   :duration 10
+                   :service \"bar\"
+                   :state \"critical\"})
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 and < 90 during 10 sec or more."
   [opts & children]
   (dt/between (:min-threshold opts) (:max-threshold opts) (:duration opts)
-    (with :state "critical"
+    (with :state (:state opts)
       (fn [event]
         (call-rescue event children)))))
 
@@ -342,10 +337,10 @@ Example:
             :above-during above-during
             :below-during below-during
             :outside-during outside-during
+            :between-during between-during
             :scount scount
             :scount-crit scount-crit
             :percentiles-crit percentiles-crit
-            :between between
             :regex-dt regex-dt
             :critical critical)
         streams (mapv (fn [config]

--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -130,7 +130,7 @@
       (fn [event]
         (call-rescue event children)))))
 
-(defn outside
+(defn outside-during
   "If the condition `(or (< (:metric event) low) (> (:metric event) high))` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives.
 
   `opts` keys:
@@ -140,14 +140,15 @@
 
   Example:
 
-  (outside {:min-threshold 70
-            :max-threshold 90
-            :duration 10})
+  (outside-during {:min-threshold 70
+                   :max-threshold 90
+                   :duration 10
+                   :state \"critical\"})
 
   Set `:state` to \"critical\" if events `:metric` is < to 70 or > 90 during 10 sec or more."
   [opts & children]
   (dt/outside (:min-threshold opts) (:max-threshold opts) (:duration opts)
-    (with :state "critical"
+    (with :state (:state opts)
       (fn [event]
         (call-rescue event children)))))
 
@@ -340,9 +341,9 @@ Example:
             :condition-during condition-during
             :above-during above-during
             :below-during below-during
+            :outside-during outside-during
             :scount scount
             :scount-crit scount-crit
-            :outside outside
             :percentiles-crit percentiles-crit
             :between between
             :regex-dt regex-dt

--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -99,7 +99,7 @@
 
   Example:
 
-  (above-during {:threshold 70 :duration 10 :state 'critical'} email)
+  (above-during {:threshold 70 :duration 10 :state \"critical\"} email)
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 during 10 sec or more."
   [opts & children]
@@ -108,7 +108,7 @@
       (fn [event]
         (call-rescue event children)))))
 
-(defn below
+(defn below-during
   "If the condition `(< (:metric event) threshold)` is valid for all events
   received during at least the period `dt`, valid events received after the `dt`
   period will be passed on until an invalid event arrives. Forward to children.
@@ -116,16 +116,17 @@
 
   `opts` keys:
   - `:threshold` : The threshold used by the above stream
-  - `:duration`   : The time period in seconds.
+  - `:duration`  : The time period in seconds.
+  - `:state`     : The state of event forwarded to children.
 
   Example:
 
-  (below {:threshold 70 :duration 10} email)
+  (below-during {:threshold 70 :duration 10 :state \"critical\"} email)
 
   Set `:state` to \"critical\" if events `:metric` is < to 70 during 10 sec or more."
   [opts & children]
   (dt/below (:threshold opts) (:duration opts)
-    (with :state "critical"
+    (with :state (:state opts)
       (fn [event]
         (call-rescue event children)))))
 
@@ -338,7 +339,7 @@ Example:
             :condition condition
             :condition-during condition-during
             :above-during above-during
-            :below below
+            :below-during below-during
             :scount scount
             :scount-crit scount-crit
             :outside outside

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -94,8 +94,8 @@
 
 
 
-(deftest below-test
-  (test-stream (below {:threshold 70 :duration 10})
+(deftest below-during-test
+  (test-stream (below-during {:threshold 70 :duration 10 :state "critical"})
                [{:metric 80 :time 0}
                 {:metric 40 :time 1}
                 {:metric 40 :time 12}

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -187,9 +187,10 @@
 
   (let [out (atom [])
         child #(swap! out conj %)
-        s (generate-streams {:regex-dt [{:pattern ".*(?i)error.*"
-                                         :duration 20
-                                         :children [child]}]})]
+        s (generate-streams {:regex-during [{:pattern ".*(?i)error.*"
+                                             :duration 20
+                                             :state "critical"
+                                             :children [child]}]})]
     (s {:time 0 :metric "foo"})
     (s {:time 10 :metric "bar"})
     (s {:time 30 :metric "error"})
@@ -314,9 +315,10 @@
      {:time 61}]
     [{:time 1 :metric 6 :state "critical"}]))
 
-(deftest regex-dt-test
-  (test-stream (regex-dt {:pattern ".*(?i)error.*" 
-                          :duration 20})
+(deftest regex-during-test
+  (test-stream (regex-during {:pattern ".*(?i)error.*" 
+                              :duration 20
+                              :state "critical"})
     [{:time 0  :metric "foo"}
      {:time 10 :metric "bar"}
      {:time 30 :metric "error"}

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -91,9 +91,6 @@
                 {:metric 90 :time 13}]
                []))
 
-
-
-
 (deftest below-during-test
   (test-stream (below-during {:threshold 70 :duration 10 :state "critical"})
                [{:metric 80 :time 0}
@@ -116,10 +113,11 @@
                [{:metric 80 :state "critical" :time 12}
                 {:metric 81 :state "critical" :time 13}]))
 
-(deftest outside-test
-  (test-stream (outside {:min-threshold 70
-                         :max-threshold 90
-                         :duration 10})
+(deftest outside-during-test
+  (test-stream (outside-during {:min-threshold 70
+                                :max-threshold 90
+                                :duration 10
+                                :state "critical"})
                [{:metric 80 :time 0}
                 {:metric 100 :time 1}
                 {:metric 101 :time 12}

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -76,8 +76,8 @@
                 {:metric 9999 :time 15 :service "bar"}]
                [])))
 
-(deftest above-test
-  (test-stream (above {:threshold 70 :duration 10})
+(deftest above-during-test
+  (test-stream (above-during {:threshold 70 :duration 10 :state "critical"})
                [{:metric 40 :time 0}
                 {:metric 80 :time 1}
                 {:metric 80 :time 12}
@@ -85,7 +85,7 @@
                 {:metric 10 :time 14}]
                [{:metric 80 :state "critical" :time 12}
                 {:metric 81 :state "critical" :time 13}])
-  (test-stream (above {:threshold 70 :duration 10})
+  (test-stream (above-during {:threshold 70 :duration 10 :state "warning"})
                [{:metric 80 :time 1}
                 {:metric 40 :time 12}
                 {:metric 90 :time 13}]

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -101,11 +101,12 @@
                [{:metric 40 :state "critical" :time 12}
                 {:metric 41 :state "critical" :time 13}]))
 
-(deftest between-test
-  (test-stream (between {:min-threshold 70
-                         :max-threshold 90
-                         :duration 10})
-               [{:metric 100 :time 0}
+(deftest between-during-test
+  (test-stream (between-during {:min-threshold 70
+                                :max-threshold 90
+                                :duration 10
+                                :state "critical"})
+               [{:metric 99 :time 0}
                 {:metric 80 :time 1}
                 {:metric 80 :time 12}
                 {:metric 81 :time 13}
@@ -118,13 +119,13 @@
                                 :max-threshold 90
                                 :duration 10
                                 :state "critical"})
-               [{:metric 80 :time 0}
+               [{:metric 80  :time 0}
                 {:metric 100 :time 1}
                 {:metric 101 :time 12}
-                {:metric 1 :time 13}
-                {:metric 70 :time 14}]
+                {:metric 1   :time 13}
+                {:metric 70  :time 14}]
                [{:metric 101 :state "critical" :time 12}
-                {:metric 1 :state "critical" :time 13}]))
+                {:metric 1   :state "critical" :time 13}]))
 
 (deftest critical-test
   (test-stream (critical {:duration 10})


### PR DESCRIPTION
* refactor: rename 'above' to 'above-during' and add 'state' as parameter
* refactor: rename 'below' to 'below-during' and add 'state' as parameter
* refactor: rename 'outside' to 'outside-during' and add 'state'  as parameter
* refactor: rename 'between' to 'between-during' and add 'state' as parameter
* refactor: rename 'regex' to 'regex-during' and add 'state' as parameter
