### PR TITLE
Add a "by" function to create a sub-stream

### DIFF
--- a/src/riemann_generic/core.clj
+++ b/src/riemann_generic/core.clj
@@ -5,8 +5,6 @@
             [riemann-cond-dt.core :as dt]
             [clojure.tools.logging :refer :all]))
 
-;; (setq clojure-defun-style-default-indent t)
-
 (defn condition
   "Use the `:condition-fn` value (which should be function accepting an event) to set the event `:state` accordingly. Forward events to children
 
@@ -20,10 +18,10 @@
                                   (< (:metric %) 70))
               :state \"warning\"})
 
-  In this example, event :state will be \"warning\" if `:metric` is >= 30 and < 70" 
+  In this example, event :state will be \"warning\" if `:metric` is >= 30 and < 70"
   [opts & children]
   (let [child-stream (remove nil?
-                        [(when (:condition-fn opts)
+                       [(when (:condition-fn opts)
                           (where ((:condition-fn opts) event)
                             (with :state (:state opts)
                               (fn [event]
@@ -49,10 +47,17 @@
 
   Set `:state` to \"critical\" if events `:metric` is > to 42 and `:metric` is \"foo\" during 10 sec or more."
   [opts & children]
-  (dt/cond-dt (:condition-fn opts) (:duration opts) 
-    (with :state (:state opts) 
-      (fn [event]
-        (call-rescue event children)))))
+  (if (contains? opts :by-fields)
+    (by (map keyword (:by-fields opts))
+      (dt/cond-dt (:condition-fn opts) (:duration opts)
+        (with :state (:state opts)
+          (fn [event]
+            (call-rescue event children)))))
+    (dt/cond-dt (:condition-fn opts) (:duration opts)
+      (with :state (:state opts)
+        (fn [event]
+          (call-rescue event children))))))
+
 
 (defn above
   "if the `:metric` event value is strictly superior to the values of `:threshold` in `opts` and update the event state accordingly, and forward to children.
@@ -69,7 +74,7 @@
   [opts & children]
   (apply condition {:condition-fn #(> (:metric %) (:threshold opts))
                     :state (:state opts)}
-                   children)) 
+    children))
 
 (defn above-during
   "If the condition `(> (:metric event) threshold)` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
@@ -86,10 +91,16 @@
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 during 10 sec or more."
   [opts & children]
-  (dt/above (:threshold opts) (:duration opts)
-    (with :state (:state opts)
-      (fn [event]
-        (call-rescue event children)))))
+  (if (contains? opts :by-fields)
+    (by (map keyword (:by-fields opts))
+      (dt/above (:threshold opts) (:duration opts)
+        (with :state (:state opts)
+          (fn [event]
+            (call-rescue event children)))))
+    (dt/above (:threshold opts) (:duration opts)
+      (with :state (:state opts)
+        (fn [event]
+          (call-rescue event children))))))
 
 (defn below
   "if the `:metric` event value is strictly inferior to the values of `:threshold` in `opts` and update the event state accordingly, and forward to children.
@@ -106,7 +117,7 @@
   [opts & children]
   (apply condition {:condition-fn #(< (:metric %) (:threshold opts))
                     :state (:state opts)}
-                   children)) 
+    children))
 
 (defn below-during
   "If the condition `(< (:metric event) threshold)` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives. Forward to children.
@@ -123,10 +134,16 @@
 
   Set `:state` to \"critical\" if events `:metric` is < to 70 during 10 sec or more."
   [opts & children]
-  (dt/below (:threshold opts) (:duration opts)
-    (with :state (:state opts)
-      (fn [event]
-        (call-rescue event children)))))
+  (if (contains? opts :by-fields)
+    (by (map keyword (:by-fields opts))
+      (dt/below (:threshold opts) (:duration opts)
+        (with :state (:state opts)
+          (fn [event]
+            (call-rescue event children)))))
+    (dt/below (:threshold opts) (:duration opts)
+      (with :state (:state opts)
+        (fn [event]
+          (call-rescue event children))))))
 
 (defn outside
   "If the condition `(or (< (:metric event) low) (> (:metric event) high))` is valid for all events received, valid events received will be passed on until an invalid event arrives.
@@ -144,11 +161,11 @@
 
   Set `:state` to \"critical\" if events `:metric` is < to 70 or > 90."
   [opts & children]
-  (apply condition {:condition-fn #(or 
+  (apply condition {:condition-fn #(or
                                      (< (:metric %) (:min-threshold opts))
                                      (> (:metric %) (:max-threshold opts)))
                     :state (:state opts)}
-                   children))
+    children))
 
 (defn outside-during
   "If the condition `(or (< (:metric event) low) (> (:metric event) high))` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives.
@@ -168,10 +185,16 @@
 
   Set `:state` to \"critical\" if events `:metric` is < to 70 or > 90 during 10 sec or more."
   [opts & children]
-  (dt/outside (:min-threshold opts) (:max-threshold opts) (:duration opts)
-    (with :state (:state opts)
-      (fn [event]
-        (call-rescue event children)))))
+  (if (contains? opts :by-fields)
+    (by (map keyword (:by-fields opts))
+      (dt/outside (:min-threshold opts) (:max-threshold opts) (:duration opts)
+        (with :state (:state opts)
+          (fn [event]
+            (call-rescue event children)))))
+    (dt/outside (:min-threshold opts) (:max-threshold opts) (:duration opts)
+      (with :state (:state opts)
+        (fn [event]
+          (call-rescue event children))))))
 
 (defn between
   "If the condition `(and (> (:metric event) low) (< (:metric event) high))` is valid for all events received, valid events received will be passed on until an invalid event arrives.
@@ -191,11 +214,11 @@
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 and < 90."
   [opts & children]
-  (apply condition {:condition-fn #(and 
+  (apply condition {:condition-fn #(and
                                      (> (:metric %) (:min-threshold opts))
                                      (< (:metric %) (:max-threshold opts)))
                     :state (:state opts)}
-                   children))
+    children))
 
 (defn between-during
   "If the condition `(and (> (:metric event) low) (< (:metric event) high))` is valid for all events received during at least the period `dt`, valid events received after the `dt` period will be passed on until an invalid event arrives.
@@ -217,10 +240,16 @@
 
   Set `:state` to \"critical\" if events `:metric` is > to 70 and < 90 during 10 sec or more."
   [opts & children]
-  (dt/between (:min-threshold opts) (:max-threshold opts) (:duration opts)
-    (with :state (:state opts)
-      (fn [event]
-        (call-rescue event children)))))
+  (if (contains? opts :by-fields)
+    (by (map keyword (:by-fields opts))
+      (dt/between (:min-threshold opts) (:max-threshold opts) (:duration opts)
+        (with :state (:state opts)
+          (fn [event]
+            (call-rescue event children)))))
+    (dt/between (:min-threshold opts) (:max-threshold opts) (:duration opts)
+      (with :state (:state opts)
+        (fn [event]
+          (call-rescue event children))))))
 
 (defn regex
   "if regex `:pattern` matched `:field` of all events received, the matched events will be passed on until an invalid event arrives. The matched event `:state` will be set to `state` and forward to children.
@@ -235,16 +264,16 @@
 
   (regex {:pattern '.*(?i)error.*'
           :field \"description\"
-          :state \"critical\"} 
+          :state \"critical\"}
          children)
 
   Set `:state` to \"critical\" if metric of events contain \"error\" in field \"description\" during 10 sec or more."
   [opts & children]
   (apply condition {:condition-fn #(and
-                                      (not= ((keyword (:field opts)) %) nil) 
-                                      (re-matches (re-pattern (:pattern opts)) ((keyword (:field opts)) %)))
+                                     (not= ((keyword (:field opts)) %) nil)
+                                     (re-matches (re-pattern (:pattern opts)) ((keyword (:field opts)) %)))
                     :state (:state opts)}
-                   children))
+    children))
 
 (defn regex-during
   "if regex `:pattern` matched all events received during at least the period `dt`, matched events received after the `dt` period will be passed on until an invalid event arrives. The matched event `:state` will be set to `:state` and forward to children.
@@ -258,21 +287,21 @@
 
   Example:
 
-  (regex-during {:pattern '.*(?i)error.*' 
-                 :duration 10 
-                 :state \"critical\"} 
+  (regex-during {:pattern '.*(?i)error.*'
+                 :duration 10
+                 :state \"critical\"}
                 children)
 
   Set `:state` to \"critical\" if metric of events contain \"error\" during 10 sec or more."
   [opts & children]
   (apply condition-during {:condition-fn #(and
-                                            (not= ((keyword (:field opts)) %) nil) 
+                                            (not= ((keyword (:field opts)) %) nil)
                                             (re-matches (re-pattern (:pattern opts)) ((keyword (:field opts)) %)))
-                           :duration (:duration opts) 
-                           :state (:state opts)} 
-                          children))
+                           :duration (:duration opts)
+                           :state (:state opts)}
+    children))
 (defn ddt-condition
-  "Differentiate metrics with respect to time, emits a rate-of-change event every `dt` seconds, divided by the difference in their times. 
+  "Differentiate metrics with respect to time, emits a rate-of-change event every `dt` seconds, divided by the difference in their times.
   if the `condition-fn` apply to the rate-of-change event return true, update the event state and service accordingly, and forward to children.
   Skips events without metrics.
 
@@ -311,10 +340,10 @@
 
   Set `:state` to \"critical\"  and `:service` to `ddt_`+ \"service\" of event if the derivate of metric every 2 seconds is superior to 5"
   [opts & children]
-  (apply ddt-condition {:condition-fn  #(> (:metric %) (:threshold opts))
+  (apply ddt-condition {:condition-fn #(> (:metric %) (:threshold opts))
                         :dt (:dt opts)
                         :state (:state opts)}
-                       children))
+    children))
 
 (defn ddt-below
   "Differentiate metrics with respect to time, emits a rate-of-change event every `dt` seconds, divided by the difference in their times. if the `:metric` rate-of-change event is inferior to the threshold `threshold`, update the event state and service accordingly, and forward to children.
@@ -333,19 +362,19 @@
 
   Set `:state` to \"critical\"  and `:service` to `ddt_`+ \"service\" of event if the derivate of metric every 2 seconds is inferior to 5"
   [opts & children]
-  (apply ddt-condition {:condition-fn  #(< (:metric %) (:threshold opts))
+  (apply ddt-condition {:condition-fn #(< (:metric %) (:threshold opts))
                         :dt (:dt opts)
                         :state (:state opts)}
-                       children))
+    children))
 
 (defn downsample
-  "Generate a new event from events every `duration` seconds foreach `by` fields distinct. The new event will have `:ttl` as ttl and new-service-fn(service) as service 
+  "Generate a new event from events every `duration` seconds foreach `by` fields distinct. The new event will have `:ttl` as ttl and new-service-fn(service) as service
 
   `opts` keys:
   - `by`             : Map of keyword of event, generate a new event foreach fields
   - `duration`       : Duration of downsampling
   - `:ttl`           : The ttl of event forwarded to children.
-  - `:new-service-fn`: How to generate the new service of event from service 
+  - `:new-service-fn`: How to generate the new service of event from service
   Example:
   (downsample {:by [:host :service]
                :duration 3
@@ -364,16 +393,16 @@
 (defn percentile-crit
   [opts & children]
   (let [child-streams (remove nil?
-                  [(when-let [warning-fn (:warning-fn opts)]
-                     (where (warning-fn event)
-                       (with :state "warning"
-                         (fn [event]
-                           (call-rescue event children)))))
-                   (when-let [critical-fn (:critical-fn opts)]
-                     (where (critical-fn event)
-                       (with :state "critical"
-                         (fn [event]
-                           (call-rescue event children)))))])]
+                        [(when-let [warning-fn (:warning-fn opts)]
+                           (where (warning-fn event)
+                             (with :state "warning"
+                               (fn [event]
+                                 (call-rescue event children)))))
+                         (when-let [critical-fn (:critical-fn opts)]
+                           (where (critical-fn event)
+                             (with :state "critical"
+                               (fn [event]
+                                 (call-rescue event children)))))])]
     (where (service (str (:service opts) " " (:point opts)))
       (apply sdo child-streams))))
 
@@ -401,8 +430,8 @@ Example:
   (let [points (mapv first (:points opts))
         percentiles-streams (mapv (fn [[point conf]]
                                     (percentile-crit
-                                     (assoc conf :service (:service opts)
-                                                 :point point)
+                                      (assoc conf :service (:service opts)
+                                                  :point point)
                                       (first children)))
                               (:points opts))
         children (conj percentiles-streams (second children))]
@@ -453,7 +482,7 @@ Example:
   children."
   [opts & children]
   (let [child-streams (remove nil? [(when-let [critical-fn (:critical-fn opts)]
-                                      (where  (critical-fn event)
+                                      (where (critical-fn event)
                                         (with :state "critical"
                                           (fn [event]
                                             (call-rescue event children)))))
@@ -511,8 +540,8 @@ Example:
                             (where (match-clause event)
                               stream)
                             stream)))
-                     streams-config)]
-     (apply sdo streams)))
+                  streams-config)]
+    (apply sdo streams)))
 
 (defn generate-streams
   [config]

--- a/test/riemann_generic/core_test.clj
+++ b/test/riemann_generic/core_test.clj
@@ -24,8 +24,8 @@
 
 (deftest condition-during-test
   (testing "should find event over 9000 during 10s "
-    (test-stream (condition-during {:condition-fn #(and 
-                                                     (> (:metric %) 9000) 
+    (test-stream (condition-during {:condition-fn #(and
+                                                     (> (:metric %) 9000)
                                                      (compare (:service %) "power"))
                                        :duration 10
                                        :state "disaster"})
@@ -56,8 +56,8 @@
       [{:metric 9002 :state "disaster" :time 12 :service "power" :endpoint "/foo"}
        {:metric 9500 :state "disaster" :time 13 :service "power" :endpoint "/foo"}]))
   (testing "should not find event over 9000 during 10s with instabilized metrics "
-    (test-stream (condition-during {:condition-fn #(and 
-                                                     (> (:metric %) 9000) 
+    (test-stream (condition-during {:condition-fn #(and
+                                                     (> (:metric %) 9000)
                                                      (compare (:service %) "power"))
                                        :duration 10
                                        :state "disaster"})
@@ -94,6 +94,38 @@
                 {:metric 40 :time 12}
                 {:metric 90 :time 13}]
                [])
+  (test-stream (above-during {:threshold 70 :duration 10 :state "critical"})
+              [{:metric 80 :device "a" :time 1}
+               {:metric 10 :device "b" :time 1}
+               {:metric 81 :device "a" :time 5}
+               {:metric 11 :device "b" :time 5}
+               {:metric 82 :device "a" :time 12}
+               {:metric 12 :device "b" :time 12}]
+              [])
+  (test-stream (above-during {:threshold 70 :duration 10 :state "critical" :by-fields nil})
+              [{:metric 80 :device "a" :time 1}
+               {:metric 10 :device "b" :time 1}
+               {:metric 81 :device "a" :time 5}
+               {:metric 11 :device "b" :time 5}
+               {:metric 82 :device "a" :time 12}
+               {:metric 12 :device "b" :time 12}]
+              [])
+  (test-stream (above-during {:threshold 70 :duration 10 :state "critical" :by-fields [nil]})
+              [{:metric 80 :device "a" :time 1}
+               {:metric 10 :device "b" :time 1}
+               {:metric 81 :device "a" :time 5}
+               {:metric 11 :device "b" :time 5}
+               {:metric 82 :device "a" :time 12}
+               {:metric 12 :device "b" :time 12}]
+              [])
+  (test-stream (above-during {:threshold 70 :duration 10 :state "critical" :by-fields [:device nil]})
+              [{:metric 80 :device "a" :time 1}
+               {:metric 10 :device "b" :time 1}
+               {:metric 81 :device "a" :time 5}
+               {:metric 11 :device "b" :time 5}
+               {:metric 82 :device "a" :time 12}
+               {:metric 12 :device "b" :time 12}]
+              [{:metric 82 :device "a" :state "critical" :time 12}])
   (test-stream (above-during {:threshold 70 :duration 10 :state "critical" :by-fields [:device]})
                [{:metric 80 :device "a" :time 1}
                 {:metric 10 :device "b" :time 1}
@@ -149,6 +181,14 @@
                 {:metric 90 :time 14}]
                [{:metric 40 :state "critical" :time 12}
                 {:metric 41 :state "critical" :time 13}])
+  (test-stream (below-during {:threshold 70 :duration 10 :state "critical" :by-fields nil})
+              [{:metric 80 :time 0}
+               {:metric 40 :time 1}
+               {:metric 40 :time 12}
+               {:metric 41 :time 13}
+               {:metric 90 :time 14}]
+              [{:metric 40 :state "critical" :time 12}
+               {:metric 41 :state "critical" :time 13}])
   (test-stream (below-during {:threshold 70 :duration 10 :state "critical" :by-fields [:device]})
     [{:metric 80 :device "a" :time 1}
      {:metric 10 :device "b" :time 1}
@@ -263,7 +303,7 @@
 
 (deftest regex-during-test
   (test-stream (regex-during {:pattern ".*(?i)error.*"
-                              :field "description" 
+                              :field "description"
                               :duration 20
                               :state "critical"})
     [{:time 0  :description "foo"}
@@ -272,7 +312,7 @@
      {:time 51 :description "ggwp Error"}]
     [{:time 51 :description "ggwp Error" :state "critical"}])
   (test-stream (regex-during {:pattern ".*(?i)error.*"
-                              :field "description" 
+                              :field "description"
                               :duration 20
                               :state "critical"})
     [{:time 0  :description "foo"}
@@ -328,9 +368,9 @@
      {:time 2  :service "foo" :metric -1};ignored
      {:time 3  :service "foo" :metric 2}
      {:time 4  :service "foo" :metric -3};ignored
-     {:time 5  :service "foo" :metric 14} 
+     {:time 5  :service "foo" :metric 14}
      {:time 6  :service "foo" :metric 20};ignored
-     {:time 7  :service "foo" :metric 15} 
+     {:time 7  :service "foo" :metric 15}
      {:time 8  :service "foo" :metric 20};ignored
      {:time 9  :service "foo" :metric -1}
      {:time 10 :service "foo" :metric 0}];ignored
@@ -367,9 +407,9 @@
      {:time 2  :service "foo" :metric -1};ignored
      {:time 3  :service "foo" :metric 2}
      {:time 4  :service "foo" :metric -3};ignored
-     {:time 5  :service "foo" :metric 14} 
+     {:time 5  :service "foo" :metric 14}
      {:time 6  :service "foo" :metric 20};ignored
-     {:time 7  :service "foo" :metric 16} 
+     {:time 7  :service "foo" :metric 16}
      {:time 8  :service "foo" :metric 20};ignored
      {:time 9  :service "foo" :metric -2}
      {:time 10 :service "foo" :metric 0}];ignored
@@ -395,12 +435,12 @@
      {:time 6  :metric 6 :service "foo" :host "b" }
      {:time 6  :metric 6 :service "bar" :host "b" }
      {:time 7  :metric 7 :service "foo" :host "a" }]
-    [{:time 0, :metric 0, :service "received:foo_from:a", :host "a", :ttl 300} 
+    [{:time 0, :metric 0, :service "received:foo_from:a", :host "a", :ttl 300}
      {:time 1, :metric 1, :service "received:foo_from:b", :host "b", :ttl 300}
-     {:time 1, :metric 1, :service "received:bar_from:b", :host "b", :ttl 300} 
+     {:time 1, :metric 1, :service "received:bar_from:b", :host "b", :ttl 300}
      {:time 3, :metric 3, :service "received:foo_from:a", :host "a", :ttl 300}
      {:time 3, :metric 3, :service "received:bar_from:a", :host "a", :ttl 300}
-     {:time 5, :metric 5, :service "received:foo_from:b", :host "b", :ttl 300} 
+     {:time 5, :metric 5, :service "received:foo_from:b", :host "b", :ttl 300}
      {:time 6, :metric 6, :service "received:bar_from:b", :host "b", :ttl 300}
      {:time 7, :metric 7, :service "received:foo_from:a", :host "a", :ttl 300}
     ]))
@@ -423,8 +463,8 @@
 
   (let [out (atom [])
         child #(swap! out conj %)
-        s (generate-streams {:condition-during [{:condition-fn #(and 
-                                                                  (> (:metric %) 9000) 
+        s (generate-streams {:condition-during [{:condition-fn #(and
+                                                                  (> (:metric %) 9000)
                                                                   (compare (:service %) "power"))
                                           :duration 10
                                           :state "disaster"


### PR DESCRIPTION
When using a condition on a period, it's now possible to specify a list of fields to split stream.